### PR TITLE
fix: adjust mobile layout for Samsung navbar visibility

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Vite + React + TS</title>
   </head>
   <body>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,7 @@
 
 @import "tailwindcss";
 
+@utility pb-safe {
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -129,7 +129,7 @@ const ChatPage: React.FC = () => {
     };
 
     return (
-        <div className="h-screen flex flex-col bg-gray-900">
+        <div className="h-dvh flex flex-col bg-gray-900 pb-safe">
         
             <header className="bg-gray-800 border-b border-gray-700 px-4 py-3 flex items-center justify-between">
                 <div className="flex items-center space-x-3">


### PR DESCRIPTION
 Body:                                                                                                                         ## Summary      
  - Change h-screen to h-dvh for correct viewport height on mobile devices
  - Add safe-area padding to prevent input field from hiding behind system navbar                                               - Add viewport-fit=cover meta tag for safe-area-inset support                                                               
                                                                                                                                ## Test plan                                                                                                                  - [ ] Verify input field is visible above Samsung system navbar
  - [ ] Verify layout still works on desktop browsers                                                                                                                                  